### PR TITLE
Updates Versions

### DIFF
--- a/.github/workflows/code-quality-terraform.yml
+++ b/.github/workflows/code-quality-terraform.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  TERRAFORM_VERSION: 0.12.20
+  TERRAFORM_VERSION: 0.13.2
   TERRAFORM_ACTIONS_COMMENT: true
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## Requirements
 
-This module requires Terraform version `0.12.20` or newer.
+This module requires Terraform version `0.13.0` or newer.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ variable "urls" {
 
 module "url_redirects" {
   source  = "operatehappy/s3-object-url-redirects/aws"
-  version = "0.9.0"
+  version = "1.0.0"
 
   bucket = "redirect-bucket"
   urls   = var.urls

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    aws = "> 3.4.0"
+    aws = ">= 3.4.0"
   }
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    aws = "> 2.10.0"
+    aws = "> 3.4.0"
   }
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.20"
+  required_version = ">= 0.13.0"
 
   required_providers {
     aws = "> 2.10.0"


### PR DESCRIPTION
This PR udpates the version of Terraform (`0.12.29` to `0.13.0`), the AWS Provider (to `3.4.0`) and the documentation.

I intend to release this as `1.0.0` as this module is (I believe!) feature complete.